### PR TITLE
.epp should always be the preferred extension by convention

### DIFF
--- a/arm-3.puppet_templates/puppet_templates.md
+++ b/arm-3.puppet_templates/puppet_templates.md
@@ -115,11 +115,10 @@ It is suggested, but not mandatory to give EPP templates an extension that ident
 The reason why it is optional is because some files have to have a precise and fixed name (in order to be able to
 open/edit it with a suitable editor).
 
-By convention, EPP templates should be named with the extension `.epp`, or with the extension next to last in order to
-preserve the real extension as a description of the content type; e.g. `.epp.html`.
+By convention, EPP templates should be named with the extension `.epp`.
 
     404page.epp
-    404page.epp.html
+    404page.html.epp
 
 Both of these signal that this is an epp file, and could be used like
 this:


### PR DESCRIPTION
There are a handful of reasons for this, the primary reasons being consistency and ease of editor support. This is the recommended behavior with ERB which EPP should match for logical consistency in template handling. Support for the EPP syntax will need to be added to most common editors, and the `.epp` extension (or in this example `.html.epp`) is the easiest way to identify the syntax to use (rather than relying on magic comments or manual intervention).
