### PR TITLE
Mark ARM-9 withdrawn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Index of ARMs
 </tr><tr>
   <td>9</td>
   <td><a href="arm-9.data_binding/index.md">Data Bindings</a></td>
-  <td>Next iteration of automatic data bindings</td>
-  <td>0.1.0</td>
-  <td>March 1, 2013</td>
-  <td>Draft</td>
+  <td><del>Next iteration of automatic data bindings</del></td>
+  <td><del>0.1.0</del></td>
+  <td><del>March 1, 2013</del></td>
+  <td>Withdrawn</td>
 </tr><tr>
   <td>10</td>
   <td><a href="arm-10.additional_node_scope/index.md">Additional Node Scope</a></td>

--- a/arm-9.data_binding/index.md
+++ b/arm-9.data_binding/index.md
@@ -1,4 +1,4 @@
-Index
-=====
+ARM-9 Data Bindings
+===================
 
-* [Data Binding](data_binding.md)
+* This ARM was withdrawn because its problem scope was subsumed in ARM-8.


### PR DESCRIPTION
No activity on this as an independent proposal, plus its
scope was subsumed into ARM-8 about dependency injection.
