### PR TITLE
PRFC-22 - Adds a Puppet RFC for HTTP Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,5 +186,14 @@ Index of PRFCs
     <td>0.0.1</td>
     <td>-</td>
     <td>New. <a href="https://groups.google.com/forum/#!topic/puppet-dev/">Discuss TBD</a></td>
+</tr><tr>
+    <td>22</td>
+    <td><a href="prfc-22.http_auth/index.md">HTTP Authorization Framework</a></td>
+    <td><a href="https://docs.google.com/document/d/1XIsGAg0Dm_aF5YWzvzZwkYaGQ15XoLVONCgYiBv9RpI/edit">Clojure-based 
+    implementation of HTTP Authorization system</a></td>
+    <td>1.0</td>
+    <td>2015-09-15</td>
+    <td>Posted - <a href="https://groups.google.com/d/topic/puppet-dev/I4GVsA46C5g/discussion">puppet-dev 
+    thread</a></td>
 </tr>
 </table>

--- a/prfc-22.http_auth/index.md
+++ b/prfc-22.http_auth/index.md
@@ -1,0 +1,6 @@
+PRFC-22 HTTP Authorization Framework
+====================
+
+### Please see the google doc at https://docs.google.com/document/d/1XIsGAg0Dm_aF5YWzvzZwkYaGQ15XoLVONCgYiBv9RpI/edit
+
+The content will end up here once the discussion period has closed.

--- a/prfc-22.http_auth/metadata.json
+++ b/prfc-22.http_auth/metadata.json
@@ -1,0 +1,13 @@
+{
+   "prfc": 22,
+   "title": "HTTP Authorization Framework",
+   "advocate":"ahpook",
+   "project":"https://github.com/puppetlabs/trapperkeeper-authorization",
+   "revision":"1.0.0",
+   "requires":[
+   ],
+   "issues":[ "https://tickets.puppetlabs.com/browse/SERVER-111",
+   ],
+   "implementation":[
+   ],
+}


### PR DESCRIPTION
This commit adds a directory and link off the index page for PRFC-22.

Closes #79.